### PR TITLE
feat: add windows support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ INSTALL
 
     pip install hebikani
 
-If you are missing libraries check the  `documentation <https://hebikani.readthedocs.io/en/latest/install.html>`_
+Check the  `documentation <https://hebikani.readthedocs.io/en/latest/install.html>`_ to install audio libraries on OSX and Linux or if the japanese characters do not display on Windows.
 
 RUN
 ---

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -5,14 +5,13 @@ Python Version
 --------------
 
 We recommend using the latest version of Python. 3.9 and newer.
-This program does not support windows system.
 
 .. code-block:: bash
 
     pip install hebikani
 
-**Note**: You will need the dependencies described below to run this program.
 
+**Note**: You will need the dependencies described below to run this program.
 
 Dependencies
 ------------
@@ -46,6 +45,16 @@ We need it for:
 * `PyGObject`_ (required to play audio).
 
 .. _PyGObject: https://pypi.org/project/pygobject/
+
+
+Windows
+~~~~~~~
+
+.. warning::
+
+    | In the event that the Japanese characters do not display, make sure that you are using a TrueType font that supports Japanese. **SimSun-ExtB** is a good choice.
+    |
+    | On PowerShell you can change the font by clicking on the icon in the top-left corner of the window and select Properties, then change to the Fonts tab and select **SimSun-ExtB**.
 
 
 Development

--- a/hebikani/input.py
+++ b/hebikani/input.py
@@ -76,7 +76,8 @@ class KanaWordBuilder:
 
 
 if sys.platform == "win32":
-    raise NotImplementedError("This program is not compatible with Windows.")
+    from msvcrt import getch  # type: ignore
+
 else:  # macOS and Linux
     import termios
     import tty
@@ -99,36 +100,38 @@ else:  # macOS and Linux
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
         return ch
 
-    def input_kana(prompt):
-        if not isinstance(prompt, str):
-            raise TypeError(
-                "prompt argument must be a str, not %s" % (type(prompt).__name__)
-            )
 
-        kana_word_builder = KanaWordBuilder("")
-        sys.stdout.write(prompt)
-        sys.stdout.flush()
-        while True:
-            key = ord(getch())
-            if key == 13:  # Enter key pressed.
-                sys.stdout.write("\n")
-                return kana_word_builder.kana
-            # Backspace/Del key erases previous output.
-            elif key in (8, 127):
-                if len(kana_word_builder.kana) > 0:
-                    # Erases previous character.
-                    kana_word_builder.remove_last_char()
-                    sys.stdout.write(f"\r\x1b[K{prompt}{kana_word_builder.kana}")
-                    sys.stdout.flush()
+def input_kana(prompt):
+    """Get user input to be converted to hiragana or katakana."""
+    if not isinstance(prompt, str):
+        raise TypeError(
+            "prompt argument must be a str, not %s" % (type(prompt).__name__)
+        )
 
-            elif 0 <= key <= 31:
-                # Do nothing for unprintable characters.
-                # TODO: Handle Esc, F1-F12, arrow keys, home, end,
-                # insert,　del, pgup, pgdn
-                pass
-            else:
-                # Key is part of the password; display the mask character.
-                char = chr(key)
-                kana_word_builder.add_romaji(char)
-                sys.stdout.write(f"\r{prompt}{kana_word_builder.kana}")
+    kana_word_builder = KanaWordBuilder("")
+    sys.stdout.write(prompt)
+    sys.stdout.flush()
+    while True:
+        key = ord(getch())
+        if key == 13:  # Enter key pressed.
+            sys.stdout.write("\n")
+            return kana_word_builder.kana
+        # Backspace/Del key erases previous output.
+        elif key in (8, 127):
+            if len(kana_word_builder.kana) > 0:
+                # Erases previous character.
+                kana_word_builder.remove_last_char()
+                sys.stdout.write(f"\r\x1b[K{prompt}{kana_word_builder.kana}")
                 sys.stdout.flush()
+
+        elif 0 <= key <= 31:
+            # Do nothing for unprintable characters.
+            # TODO: Handle Esc, F1-F12, arrow keys, home, end,
+            # insert,　del, pgup, pgdn
+            pass
+        else:
+            # Key is part of the password; display the mask character.
+            char = chr(key)
+            kana_word_builder.add_romaji(char)
+            sys.stdout.write(f"\r{prompt}{kana_word_builder.kana}")
+            sys.stdout.flush()

--- a/poetry.lock
+++ b/poetry.lock
@@ -225,6 +225,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "mutagen"
+version = "1.45.1"
+description = "read and write audio tags for many formats"
+category = "main"
+optional = false
+python-versions = ">=3.5, <4"
+
+[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
@@ -277,7 +285,7 @@ test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytes
 
 [[package]]
 name = "playsound"
-version = "1.3.0"
+version = "1.2.2"
 description = "Pure Python, cross platform, single function module with no dependencies for playing sounds."
 category = "main"
 optional = false
@@ -2292,11 +2300,18 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "romkan"
-version = "0.2.1"
+version = "0.2.2"
 description = "A Romaji/Kana conversion library"
 category = "main"
 optional = false
 python-versions = "*"
+develop = false
+
+[package.source]
+type = "git"
+url = "https://github.com/ajite/python-romkan"
+reference = "master"
+resolved_reference = "411ad7aadc3d39a46ee271ffbee7697f0a25e1e7"
 
 [[package]]
 name = "six"
@@ -2488,7 +2503,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "1fdd37cacf6ce9277f067d60466552ebf2231cc66d5f13743123af630fc648d3"
+content-hash = "332048f1028d07348c52bb7d84b0dc3286bf5a779c3e801652b1428860d3d47e"
 
 [metadata.files]
 alabaster = [
@@ -2673,6 +2688,10 @@ mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
+mutagen = [
+    {file = "mutagen-1.45.1-py3-none-any.whl", hash = "sha256:9c9f243fcec7f410f138cb12c21c84c64fde4195481a30c9bfb05b5f003adfed"},
+    {file = "mutagen-1.45.1.tar.gz", hash = "sha256:6397602efb3c2d7baebd2166ed85731ae1c1d475abca22090b7141ff5034b3e1"},
+]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
@@ -2730,7 +2749,7 @@ platformdirs = [
     {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
 ]
 playsound = [
-    {file = "playsound-1.3.0.tar.gz", hash = "sha256:cc6ed11d773034b0ef624e6bb4bf50f4b76b8414a59ce6d38afb89b423297ced"},
+    {file = "playsound-1.2.2-py2.py3-none-any.whl", hash = "sha256:1e83750a5325cbccee03d6e751ba3e78c037ac95b95a3ba1f38d0c5aca9e1a34"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -3555,10 +3574,7 @@ requests = [
     {file = "requests-2.28.0-py3-none-any.whl", hash = "sha256:bc7861137fbce630f17b03d3ad02ad0bf978c844f3536d0edda6499dafce2b6f"},
     {file = "requests-2.28.0.tar.gz", hash = "sha256:d568723a7ebd25875d8d1eaf5dfa068cd2fc8194b2e483d7b1f7c81918dbec6b"},
 ]
-romkan = [
-    {file = "romkan-0.2.1-py3.3.egg", hash = "sha256:cc6f66c96973c04dd9bfedbe0e5e01170e4e8ecedd483d960f42aa94cb9cf144"},
-    {file = "romkan-0.2.1.tar.gz", hash = "sha256:a530245a38969704700e0ca8f9cb7158c4ede91c5fd1e24677dbe814cf91f33b"},
-]
+romkan = []
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,14 @@ repository = "https://github.com/ajite/hebikani"
 [tool.poetry.dependencies]
 python = "^3.9"
 requests = "^2.27.1"
-romkan = "^0.2.1"
 ascii-magic = "^1.6"
 Pillow = "^9.1.0"
-playsound = "^1.3.0"
 pyobjc = {version = "^8.5", platform = "darwin"}
 colorama = "^0.4.4"
 PyGObject = {version = "^3.42.1", platform = "linux"}
+romkan = {git = "https://github.com/ajite/python-romkan", rev = "master"}
+playsound = "1.2.2"
+mutagen = {version = "^1.45.1", platform = "win32"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,8 +1,4 @@
-from importlib import reload
-from unittest.mock import patch
-
 import hebikani.input as input_kana
-import pytest
 
 
 def test_kana_builder():
@@ -67,19 +63,3 @@ def test_add_char_to_builder():
 
     word.add_romaji("a")
     assert word.kana == "おはヨYおっは"
-
-
-@patch("hebikani.input.sys.platform", "win32")
-def test_windows_not_implemented():
-    """Test that the windows implementation is not implemented."""
-    with pytest.raises(NotImplementedError):
-        reload(input_kana)
-
-
-@patch("hebikani.input.sys.platform", "darwin")
-def test_osx_implemented():
-    """Test that the OSX implementation is implemented."""
-    try:
-        reload(input_kana)
-    except NotImplementedError:
-        pytest.fail("NotImplementedError raised")


### PR DESCRIPTION
Added mutagen for windows install since playsound has issue playing WaniKani's mp3
Mutagen removes the mp3 tag and that makes it work on windows.

We are not saving temporary files and delete them manually.
It was making permission error on windows.

Updated documentation to include Windows install.

Updated tests when removing cache (since we are keeping the files and delete them manually)

Removed tests that were checking that windows is not implemented.