### PR TITLE
feat: prevent sending empty answer and handle ctrl + c in reading

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,3 +9,4 @@ per-file-ignores =
 exclude =
     .venv
     build
+    dist

--- a/hebikani/hebikani.py
+++ b/hebikani/hebikani.py
@@ -9,6 +9,7 @@ Usage:
     >>> from hebikani import hebikani
     >>> client = hebikani.Client(API_KEY)
 """
+import atexit
 import datetime
 import os
 import random
@@ -134,7 +135,7 @@ def clear_audio_cache():
         os.unlink(audio_file.name)
 
 
-def handler(signal_received, frame):
+def handler(signal_received=None, frame=None):
     """Terminate the program gracefully."""
     clear_terminal()
     print("Program was terminated by user.\n\n")
@@ -1144,9 +1145,17 @@ class ReviewSession(Session):
             )
 
         if question.question_type == QuestionType.MEANING:
-            inputed_answer = input(prompt)
+            inputed_answer = None
+            while not inputed_answer:
+                inputed_answer = input(prompt)
+                if not inputed_answer:
+                    print("\a")
         else:
-            inputed_answer = input_kana(prompt)
+            try:
+                inputed_answer = input_kana(prompt)
+            except KeyboardInterrupt:
+                handler()
+
 
         answer_type = question.solve(inputed_answer, self.client.options.hard_mode)
         return answer_type

--- a/hebikani/hebikani.py
+++ b/hebikani/hebikani.py
@@ -9,7 +9,6 @@ Usage:
     >>> from hebikani import hebikani
     >>> client = hebikani.Client(API_KEY)
 """
-import atexit
 import datetime
 import os
 import random
@@ -34,8 +33,14 @@ from playsound import playsound
 from hebikani import __version__
 from hebikani.graph import hist
 from hebikani.input import getch, input_kana
-from hebikani.typing import (AnswerType, Gender, HTTPMethod, QuestionType,
-                             SubjectObject, VoiceMode)
+from hebikani.typing import (
+    AnswerType,
+    Gender,
+    HTTPMethod,
+    QuestionType,
+    SubjectObject,
+    VoiceMode,
+)
 
 if system() == "Windows":
     from mutagen.mp3 import MP3
@@ -1155,7 +1160,6 @@ class ReviewSession(Session):
                 inputed_answer = input_kana(prompt)
             except KeyboardInterrupt:
                 handler()
-
 
         answer_type = question.solve(inputed_answer, self.client.options.hard_mode)
         return answer_type


### PR DESCRIPTION
User can't send empty meaning or reading. A system beep is sent when try to do so.

User can now ctrl + c out of reading questions.

We used the raw.read in linux,osx getch method since windows getch returned binary as well.