### PR TITLE
fix: lesson arrow navigation stopped working

### DIFF
--- a/hebikani/hebikani.py
+++ b/hebikani/hebikani.py
@@ -1252,7 +1252,8 @@ class LessonSession(Session):
 
             # Only accept valid keys
             while key not in [10, 67, 68]:
-                key = ord(getch(use_raw_input=False))
+                chr = getch(use_raw_input=False)
+                key = ord(chr)
             if key == 67 or key == 10:  # Right
                 # sys.stdout.write("\n")
                 tab_index += 1

--- a/hebikani/input.py
+++ b/hebikani/input.py
@@ -98,11 +98,11 @@ else:  # macOS and Linux
                 tty.setraw(sys.stdin.fileno())
             else:
                 tty.setcbreak(sys.stdin.fileno())
-            ch = sys.stdin.buffer.raw.read(1)
+            ch = sys.stdin.read(1)
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
 
-        return ch
+        return ch.encode('utf-8')
 
 
 def input_kana(prompt):


### PR DESCRIPTION
Using sys.stdin.raw.read(1) was giving the same input for arrow keys.
Switch it back to what it was before but encoded it to utf8 to get ctrl + c