### PR TITLE
feat: improve reviews queue management

### DIFF
--- a/hebikani/input.py
+++ b/hebikani/input.py
@@ -102,7 +102,7 @@ else:  # macOS and Linux
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
 
-        return ch.encode('utf-8')
+        return ch.encode("utf-8")
 
 
 def input_kana(prompt):
@@ -125,7 +125,7 @@ def input_kana(prompt):
             raise KeyboardInterrupt
 
         key = ord(ch)
-        if key == 13 and re.compile(r"^[ぁ-んァ-ン,]+$").match(kana_word_builder.kana):
+        if key == 13 and re.compile(r"^[ぁ-んァ-ン,ー]+$").match(kana_word_builder.kana):
             sys.stdout.write("\n")
             return kana_word_builder.kana
         # Backspace/Del key erases previous output.

--- a/tests/test_hebikani.py
+++ b/tests/test_hebikani.py
@@ -204,7 +204,7 @@ def test_review_session_audio_mode(audio_play_mock, input_mock):
     options = ClientOptions(voice_mode=VoiceMode.FEMALE)
     client = Client(API_KEY, options)
     session = ReviewSession(client, [subject] * 10)
-
+    session.queue.rebuild(session.subjects)
     # Test only with reading card type
     assert len(session.queue) == 20
 
@@ -418,6 +418,7 @@ def test_review_session():
     subject = Subject(vocabulary_subject)
     client = Client(API_KEY)
     session = ReviewSession(client, [subject] * 10)
+    session.queue.rebuild(session.subjects)
     assert len(session.queue) == 20
     assert session.nb_subjects == 10
 


### PR DESCRIPTION
Reviews are now taken 10 by 10. When completing an item a new item will be added to the queue.

When an item is wrong, the item will go back at the end of the queue after the shuffle.

It avoid the same question to be asked twice in a row. It makes it easier.

Keeping a queue of 10 itwms (max 20 questions or less with radicals), makes it easier to interrupt a session.