### PR TITLE
fix: mark answer in ReviewSession.process_answer instead of Question.solve

### DIFF
--- a/hebikani/hebikani.py
+++ b/hebikani/hebikani.py
@@ -1064,11 +1064,6 @@ class Question:
                     AnswerType.INEXACT if _answer == AnswerType.CORRECT else _answer
                 )
 
-        if _answer == AnswerType.INCORRECT:
-            self.wrong_answer_count += 1
-        elif _answer == AnswerType.CORRECT:
-            self.solved = True
-
         return _answer
 
     def add_wrong_answer(self):
@@ -1296,6 +1291,7 @@ class ReviewSession(Session):
         if answer_type == AnswerType.CORRECT:
             print("\nCorrect!")
             self.nb_correct_answers += 1
+            question.solved = True
 
         # If the user is a bit off, we show the correct answer and ask
         # to validate his answer
@@ -1343,6 +1339,7 @@ class ReviewSession(Session):
 
             if answer_was_correct not in ["y", "Y"]:
                 self.nb_incorrect_answers += 1
+                question.add_wrong_answer()
                 self.queue.shuffle()
                 # Add the question at the end of the queue
                 # So we don't have it twice in a row.

--- a/tests/test_hebikani.py
+++ b/tests/test_hebikani.py
@@ -419,10 +419,15 @@ def test_card_is_solved():
     subject = Subject(vocabulary_subject)
     # To avoid making a query online to get the kanji auxiliaries
     Cache.subjects[440] = subject
+    client = Client(API_KEY)
+    session = ReviewSession(client, [subject])
+
     assert subject.solved is False
 
-    subject.meaning_question.solve("one")
-    subject.reading_question.solve("いち")
+    answer_type = subject.meaning_question.solve("one")
+    session.process_answer(subject.meaning_question, answer_type)
+    answer_type = subject.reading_question.solve("いち")
+    session.process_answer(subject.reading_question, answer_type)
 
     assert subject.solved is True
 
@@ -430,8 +435,10 @@ def test_card_is_solved():
 
     assert subject.solved is False
 
-    subject.meaning_question.solve("hello")
-    subject.reading_question.solve("いち")
+    answer_type = subject.meaning_question.solve("hello")
+    session.process_answer(subject.meaning_question, answer_type)
+    answer_type = subject.reading_question.solve("いち")
+    session.process_answer(subject.reading_question, answer_type)
 
     assert subject.solved is False
     Cache.subjects = {}

--- a/tests/test_hebikani.py
+++ b/tests/test_hebikani.py
@@ -337,6 +337,35 @@ def test_question_add_wrong_answers():
     assert question.wrong_answer_count == 2
 
 
+# first value is input for answer; the second is input for double_check
+@patch("builtins.input", side_effect=["change me to correct", "y"])
+def test_double_check_y(input_mock):
+    """Test if the question is not marked wrong when double check overrides it."""
+    subject = Subject(get_specific_subjects["data"][0])
+    options = ClientOptions(double_check=True)
+    client = Client(API_KEY, options)
+    session = ReviewSession(client, [subject])
+    question = subject.meaning_question
+    answer_type = session.ask_answer(question)
+    print(answer_type)
+    session.process_answer(question, answer_type)
+    assert question.wrong_answer_count == 0
+
+
+# first value is input for answer; the second is input for double_check
+@patch("builtins.input", side_effect=["leave me incorrect", "n"])
+def test_double_check_n(input_mock):
+    """Test if the question is marked wrong when double check does not override it."""
+    subject = Subject(get_specific_subjects["data"][0])
+    options = ClientOptions(double_check=True)
+    client = Client(API_KEY, options)
+    session = ReviewSession(client, [subject])
+    question = subject.meaning_question
+    answer_type = session.ask_answer(question)
+    session.process_answer(question, answer_type)
+    assert question.wrong_answer_count == 1
+
+
 def test_question_answer_values():
     """Test the question answer values."""
     subject = Subject(double_reading_subject)


### PR DESCRIPTION
The logic for marking whether a question was correct or incorrect was split between `ReviewSession.process_answer` and `Question.solve`. If it was Correct or Incorrect, the question was mutated in `solve` but otherwise it was resolved in `process_answer`. This was causing a problem with the double_check feature. Because even if the result was changed in `process_answer` since it was already marked incorrect in 'solve' it was submitted to wanikani as incorrect.

---

The first commit adds tests for double check. They fail on master (#66).

The second commit moves the CORRECT and INCORRECT handling into `process_answer`. This way, the INCORRECT is handled almost the same way as A_BIT_OFF.

This did break the test `test_card_is_solved` since now the card is only marked solved after `process_answer`. Adding a session and processing each answer made that test match the new way of marking answers.


fixes #66 